### PR TITLE
chore: upgrade npm version and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 coverage/
 .vscode/
 .direnv/
+.pnpm-store
 .npm-store

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,7 +16,8 @@
 #@   "nodejs_task_image_config",
 #@   "slack_resource",
 #@   "gcr_resource_type",
-#@   "slack_resource_type")
+#@   "slack_resource_type",
+#@   "npm_resource_type")
 
 
 #! Do nothing for now!
@@ -178,7 +179,4 @@ resources:
 resource_types:
 - #@ gcr_resource_type()
 - #@ slack_resource_type()
-- name: npm
-  type: docker-image
-  source:
-    repository: timotto/concourse-npm-resource
+- #@ npm_resource_type()


### PR DESCRIPTION
This PR uses the concourse-shared version of the npm-concourse-resource instead of its own one.

And that resource changed here (merged already):
https://github.com/blinkbitcoin/concourse-shared/pull/8

So this PR should get merged after those changes.

